### PR TITLE
set parallelize to false for cpu

### DIFF
--- a/src/hflm/lm_gen/__main__.py
+++ b/src/hflm/lm_gen/__main__.py
@@ -28,9 +28,14 @@ def lm_gen():
         logging.error("String required.")
         sys.exit(1)
 
+    if args.device == "cpu":
+        parallelize = False
+    else:
+        parallelize = True
+
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore')
-        model = HFLM(model=args.model, device=args.device, parallelize=True)
+        model = HFLM(model=args.model, device=args.device, parallelize=parallelize)
 
         if args.temperature == 0.0: 
             do_sample = False

--- a/src/hflm/lm_prob/__main__.py
+++ b/src/hflm/lm_prob/__main__.py
@@ -23,10 +23,16 @@ def lm_prob():
         logging.error("String required.")
         sys.exit(1)
 
+    if args.device == "cpu":
+        parallelize = False
+    else:
+        parallelize = True
+
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore')
-        model = HFLM(model=args.model, device=args.device)
+        model = HFLM(model=args.model, device=args.device, parallelize=parallelize)
         print(model.loglikelihood_rolling([args.string], disable_tqdm=True)[0])
 
 if __name__ == "__main__":
     lm_prob()
+


### PR DESCRIPTION
fixes the bug seen when running with `parallelize=True` and `device='cpu'`