### PR TITLE
Switched to only checking for trust_remote_code in tokenizer init.

### DIFF
--- a/src/hflm/huggingface_model.py
+++ b/src/hflm/huggingface_model.py
@@ -148,11 +148,15 @@ class HFLM(LM):
         # get backend
         self._get_backend()
 
+        trust_remote_code = False
+        if "trust_remote_code" in kwargs:
+            trust_remote_code = kwargs["trust_remote_code"]
+
         # create tokenizer
         self._create_tokenizer(
             model,
             tokenizer,
-            **kwargs
+            trust_remote_code
         )
 
         # create model


### PR DESCRIPTION
Bug fix for when multiple kwargs get passed to the model.