### PR TITLE
add the disable_tqdm param into _loglikelihood_tokens call

### DIFF
--- a/src/hflm/huggingface_model.py
+++ b/src/hflm/huggingface_model.py
@@ -564,7 +564,7 @@ class HFLM(LM):
 
             new_reqs.append(((context, continuation), context_enc, continuation_enc))
 
-        return self._loglikelihood_tokens(new_reqs, override_bs=adaptive_batch_size)
+        return self._loglikelihood_tokens(new_reqs, disable_tqdm=disable_tqdm, override_bs=adaptive_batch_size)
 
     def _model_call(self, inps, attn_mask=None, labels=None):
         with torch.no_grad():


### PR DESCRIPTION
very minor PR that allows users to disable tqdm in loglikelihood calls 